### PR TITLE
Fix the wrong state of an OCF button resource

### DIFF
--- a/app/templates/sensor-button.html
+++ b/app/templates/sensor-button.html
@@ -1,7 +1,7 @@
 <span class="sensor-text-value">
 	<div ng-show="sensor.data.properties.value !== undefined">
-        <span ng-show="sensor.data.properties.value === false" class="balanced">Pressed</span>
-        <span ng-show="sensor.data.properties.value === true" class="assertive">Released</span>
+        <span ng-show="sensor.data.properties.value === true" class="balanced">Pressed</span>
+        <span ng-show="sensor.data.properties.value === false" class="assertive">Released</span>
     </div>
     <div ng-show="sensor.data.properties.value === undefined">
         ...


### PR DESCRIPTION
For a button resource:
value true indicates the button is pressed.
value false indicates the button is released.
